### PR TITLE
fix(cmx): include subpalette fields in PaletteManipulatorExtended::hasField

### DIFF
--- a/src/DataContainer/PaletteManipulatorExtended.php
+++ b/src/DataContainer/PaletteManipulatorExtended.php
@@ -45,8 +45,43 @@ class PaletteManipulatorExtended extends PaletteManipulator
         return $arrFields;
     }
 
-    public function hasField(string $strPalette, string $table, string $strField){
+    /**
+     * Returns whether $strField is reachable from $strPalette - either directly in the main
+     * palette string or in a subpalette whose selector is reachable from the main palette.
+     *
+     * Whether a specific record currently activates a given subpalette (i.e. the runtime value
+     * of the selector) is a separate concern handled at call sites that need it.
+     */
+    public function hasField(string $strPalette, string $table, string $strField): bool
+    {
         Controller::loadDataContainer($table);
-        return in_array($strField,$this->getPaletteFields($strPalette, $table));
+
+        $arrPaletteFields = $this->getPaletteFields($strPalette, $table);
+
+        // 1) Direct hit in the main palette.
+        if (in_array($strField, $arrPaletteFields, true)) {
+            return true;
+        }
+
+        // 2) Hit in a subpalette whose selector is reachable from this palette.
+        $arrSelectors = (array) ($GLOBALS['TL_DCA'][$table]['palettes']['__selector__'] ?? []);
+        $arrSubpalettes = (array) ($GLOBALS['TL_DCA'][$table]['subpalettes'] ?? []);
+
+        foreach ($arrSelectors as $strSelector) {
+            if (!in_array($strSelector, $arrPaletteFields, true)) continue;
+
+            foreach ($arrSubpalettes as $strSubKey => $varSubFields) {
+                if ($strSubKey !== $strSelector && !str_starts_with((string) $strSubKey, $strSelector . '_')) continue;
+                if (!is_string($varSubFields)) continue;
+
+                foreach (StringUtil::trimsplit(',', $varSubFields) as $strSubField) {
+                    if ($strSubField === $strField) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
The helper previously inspected only the main palette string. Fields revealed via Contao subpalettes were reported as absent even when the user could legitimately reach them in the backend.

Walks subpalettes whose selector appears in the resolved main palette and in __selector__. Whether a specific record currently
activates the subpalette is a separate concern, handled at the call site if needed.

Audited all callers in the kiwi vendor tree:
  - GetFrontendModuleListener, GetAllEventsListener, ParseTemplateListener: check selectors (addResponsive/addResponsiveChildren) which are always in the main palette - unaffected.
  - ResponsiveFrontendService::isFieldInPalette (frontend palette gate): transparently picks up subpalette-only field additions by third-party bundles - no behavioural change for the current responsive-base / bootstrap dual-add pattern where fields are added to both the main palette and the relevant subpalette.
  - contao-designer LoadDataContainerListener (extends headline section): unaffected since headline is in main palettes everywhere; mildly more correct in any hypothetical case where headline lives in a subpalette.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes palette field reachability checks to consider Contao subpalettes, which can alter backend field detection/gating behavior for existing DCA configurations.
> 
> **Overview**
> Updates `PaletteManipulatorExtended::hasField()` to return true not only for fields present in the main palette string, but also for fields defined in *reachable* subpalettes (i.e., subpalettes whose selectors are present in the resolved palette and listed in `__selector__`).
> 
> This adds strict `in_array` checks, iterates matching `subpalettes` keys (including selector-prefix variants), and documents that runtime selector activation is intentionally left to call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7881780c30e949149a1e900b17c47a8e6f9067f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->