### PR TITLE
fix(PaletteManipulator): check nested subpalettes in hasField

### DIFF
--- a/src/DataContainer/PaletteManipulatorExtended.php
+++ b/src/DataContainer/PaletteManipulatorExtended.php
@@ -58,26 +58,41 @@ class PaletteManipulatorExtended extends PaletteManipulator
 
         $arrPaletteFields = $this->getPaletteFields($strPalette, $table);
 
-        // 1) Direct hit in the main palette.
-        if (in_array($strField, $arrPaletteFields, true)) {
-            return true;
-        }
-
-        // 2) Hit in a subpalette whose selector is reachable from this palette.
         $arrSelectors = (array) ($GLOBALS['TL_DCA'][$table]['palettes']['__selector__'] ?? []);
         $arrSubpalettes = (array) ($GLOBALS['TL_DCA'][$table]['subpalettes'] ?? []);
 
+        return $this->searchFields($arrPaletteFields, $strField, $arrSelectors, $arrSubpalettes, []);
+    }
+
+    /**
+     * Recursively searches $arrFields (and any subpalettes reachable via selectors) for $strField.
+     *
+     * @param string[] $arrFields     Fields to search in this level.
+     * @param string   $strField      The field we are looking for.
+     * @param string[] $arrSelectors  All selector field names of the table.
+     * @param array    $arrSubpalettes The table's subpalettes definition.
+     * @param string[] $arrVisited    Subpalette keys already visited (prevents infinite recursion).
+     */
+    private function searchFields(array $arrFields, string $strField, array $arrSelectors, array $arrSubpalettes, array $arrVisited): bool
+    {
+        // 1) Direct hit at this level.
+        if (in_array($strField, $arrFields, true)) {
+            return true;
+        }
+
+        // 2) Follow selectors that are present at this level into their subpalettes.
         foreach ($arrSelectors as $strSelector) {
-            if (!in_array($strSelector, $arrPaletteFields, true)) continue;
+            if (!in_array($strSelector, $arrFields, true)) continue;
 
             foreach ($arrSubpalettes as $strSubKey => $varSubFields) {
                 if ($strSubKey !== $strSelector && !str_starts_with((string) $strSubKey, $strSelector . '_')) continue;
                 if (!is_string($varSubFields)) continue;
+                if (in_array($strSubKey, $arrVisited, true)) continue;
 
-                foreach (StringUtil::trimsplit(',', $varSubFields) as $strSubField) {
-                    if ($strSubField === $strField) {
-                        return true;
-                    }
+                $arrSubFields = StringUtil::trimsplit(',', $varSubFields);
+
+                if ($this->searchFields($arrSubFields, $strField, $arrSelectors, $arrSubpalettes, array_merge($arrVisited, [$strSubKey]))) {
+                    return true;
                 }
             }
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small DCA lookup fix with cycle protection; no auth, data, or API surface changes beyond more accurate field detection.
> 
> **Overview**
> **`hasField`** in `PaletteManipulatorExtended` now treats fields inside **nested subpalettes** as reachable, not only fields on the main palette or one subpalette level deep.
> 
> The one-level subpalette loop is replaced by a private **`searchFields`** helper that walks selector-linked subpalettes **recursively**, with a **visited** list so repeated subpalette keys cannot loop forever.
> 
> Call sites that gate palette changes on “is this field on this palette?” should stop missing fields that only appear behind a selector inside another subpalette.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b6f010f97aacf42fb7d8429292207194bd5dfa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->